### PR TITLE
fix: del disable-scroll="{{true}}"

### DIFF
--- a/f2-canvas/f2-canvas.wxml
+++ b/f2-canvas/f2-canvas.wxml
@@ -1,10 +1,10 @@
-<canvas 
-class="f2-canvas" 
+<canvas
+class="f2-canvas"
 canvas-id="{{ canvasId }}"
-disable-scroll="{{true}}"
+disable-scroll="{{opt.disableTouch}}"
 bindinit="init"
-bindtouchstart="touchStart" 
-bindtouchmove="touchMove" 
-bindtouchend="touchEnd"
+bindtouchstart="{{opt.disableTouch ? '' : touchStart}}"
+bindtouchmove="{{opt.disableTouch ? '' : touchMove}}"
+bindtouchend="{{opt.disableTouch ? '' : touchEnd}}"
 >
 </canvas>

--- a/f2-canvas/f2-canvas.wxml
+++ b/f2-canvas/f2-canvas.wxml
@@ -1,10 +1,9 @@
 <canvas
 class="f2-canvas"
 canvas-id="{{ canvasId }}"
-disable-scroll="{{opt.disableTouch}}"
 bindinit="init"
-bindtouchstart="{{opt.disableTouch ? '' : touchStart}}"
-bindtouchmove="{{opt.disableTouch ? '' : touchMove}}"
-bindtouchend="{{opt.disableTouch ? '' : touchEnd}}"
+bindtouchstart="touchStart"
+bindtouchmove="touchMove"
+bindtouchend="touchEnd"
 >
 </canvas>


### PR DESCRIPTION
修复iphone7plus中使用f2图表绘制，默认配置disable-scroll="{{true}}"，导致页面无法滚动问题